### PR TITLE
EN-10405: Bumping version to 8.3.99

### DIFF
--- a/src/PIL/_version.py
+++ b/src/PIL/_version.py
@@ -1,2 +1,2 @@
 # Master version for Pillow
-__version__ = "8.3.2"
+__version__ = "8.3.99"

--- a/src/PIL/_version.py
+++ b/src/PIL/_version.py
@@ -1,2 +1,4 @@
 # Master version for Pillow
+# This is a not official, made up and temporary version number. Is being used as workaround for pip3 to resolve properly
+# our own pinned Pillow version
 __version__ = "8.3.99"


### PR DESCRIPTION
Bumping version to 8.3.99 in order to have a very recognisable one that isn't a official version.